### PR TITLE
README 갱신, 정리

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 <div align="center">
     
-![Flip Dot Display](https://flipdots.vercel.app/api/svg?text=GITHUB%20README&style=dark&dotSize=16&spacing=2&animationMode=scroll)
+![Flip Dot Display](https://flipdots.vercel.app/api/svg?text=GITHUB%20README&style=dark&dotSize=16&spacing=2&animationMode=scroll&v=1)
 
 </div>
 
@@ -40,17 +40,15 @@ GitHub README.md에 직접 임베드할 수 있는 flip dot 이미지를 생성�
 실제 flip-dot 하드웨어의 동작을 재현한 3가지 애니메이션 모드를 지원합니다.
 
 ### 기본 사용법
-
+![BASIC](https://flipdots.vercel.app/api/svg?text=YOUR_TEXT&style=dark)
 ```markdown
-![Flip Dot Display](https://flipdots.vercel.app/api/svg?text=YOUR_TEXT&style=dark)
-<!-- https://flipdots.vercel.app/api/svg?text=YOUR_TEXT&style=dark -->
+https://flipdots.vercel.app/api/svg?text=YOUR_TEXT&style=dark
 ```
 
 ### 애니메이션 사용법
-
+![SCROLL_EX1](https://flipdots.vercel.app/api/svg?text=HELLO%20WORLD&animationMode=scroll&style=retro)
 ```markdown
-![Scroll Animation](https://flipdots.vercel.app/api/svg?text=HELLO%20WORLD&animationMode=scroll&style=retro)
-<!-- https://flipdots.vercel.app/api/svg?text=HELLO%20WORLD&animationMode=scroll&style=retro -->
+https://flipdots.vercel.app/api/svg?text=HELLO%20WORLD&animationMode=scroll&style=retro
 ```
 
 ## 📋 파라미터
@@ -78,48 +76,59 @@ GitHub README.md에 직접 임베드할 수 있는 flip dot 이미지를 생성�
 
 ### 기본 스타일들
 
-![Light Style](https://flipdots.vercel.app/api/svg?text=LIGHT&style=light&dotSize=20&spacing=2)
-<!-- https://flipdots.vercel.app/api/svg?text=LIGHT&style=light&dotSize=20&spacing=2 -->
+![Light Style](https://flipdots.vercel.app/api/svg?text=LIGHT&style=light&dotSize=20&spacing=2&v=1)
+```markdown
+https://flipdots.vercel.app/api/svg?text=LIGHT&style=light&dotSize=20&spacing=2
+```
 
-![Retro Style](https://flipdots.vercel.app/api/svg?text=RETRO&style=retro&dotSize=20&spacing=2)
-<!-- https://flipdots.vercel.app/api/svg?text=RETRO&style=retro&dotSize=20&spacing=2 -->
-![Modern Style](https://flipdots.vercel.app/api/svg?text=MODERN&style=modern&dotSize=20&spacing=2)
-<!-- https://flipdots.vercel.app/api/svg?text=MODERN&style=modern&dotSize=20&spacing=2 -->
+![Retro Style](https://flipdots.vercel.app/api/svg?text=RETRO&style=retro&dotSize=20&spacing=2&v=1)
+```markdown
+https://flipdots.vercel.app/api/svg?text=RETRO&style=retro&dotSize=20&spacing=2
+```
+![Modern Style](https://flipdots.vercel.app/api/svg?text=MODERN&style=modern&dotSize=20&spacing=2&v=1)
+```markdown
+https://flipdots.vercel.app/api/svg?text=MODERN&style=modern&dotSize=20&spacing=2
+```
 
-![Dark Style](https://flipdots.vercel.app/api/svg?text=DARK&style=dark&dotSize=20&spacing=2)
-<!-- https://flipdots.vercel.app/api/svg?text=DARK&style=dark&dotSize=20&spacing=2 -->
+![Dark Style](https://flipdots.vercel.app/api/svg?text=DARK&style=dark&dotSize=20&spacing=2&v=1)
+```markdown
+https://flipdots.vercel.app/api/svg?text=DARK&style=dark&dotSize=20&spacing=2
+```
+
 
 ### 커스텀 색상
 
-![Custom Red](https://flipdots.vercel.app/api/svg?text=CUSTOM&dotOn=ff0000&background=000000&dotSize=20&spacing=2)
-<!-- https://flipdots.vercel.app/api/svg?text=CUSTOM&dotOn=ff0000&background=000000&dotSize=20&spacing=2 -->
+![Custom Red](https://flipdots.vercel.app/api/svg?text=CUSTOM&dotOn=ff0000&background=000000&dotSize=20&spacing=2&v=1)
+```markdown
+https://flipdots.vercel.app/api/svg?text=CUSTOM&dotOn=ff0000&background=000000&dotSize=20&spacing=2
+```
 
-![Rainbow Gradient](https://flipdots.vercel.app/api/svg?text=RAINBOW&dotOn=ff0000,ff8000,ffff00,00ff00,0000ff,8000ff&background=000000&dotSize=18&spacing=2)
-<!-- https://flipdots.vercel.app/api/svg?text=RAINBOW&dotOn=ff0000,ff8000,ffff00,00ff00,0000ff,8000ff&background=000000&dotSize=18&spacing=2 -->
+![Rainbow Gradient](https://flipdots.vercel.app/api/svg?text=RAINBOW&dotOn=ff0000,ff8000,ffff00,00ff00,0000ff,8000ff&background=000000&dotSize=18&spacing=2&v=1)
+```markdown
+https://flipdots.vercel.app/api/svg?text=RAINBOW&dotOn=ff0000,ff8000,ffff00,00ff00,0000ff,8000ff&background=000000&dotSize=18&spacing=2
+```
 
-![Purple Theme](https://flipdots.vercel.app/api/svg?text=PURPLE&dotOn=ff00ff&dotOff=330033&background=1a0a1a&dotSize=22&spacing=2)
-<!-- https://flipdots.vercel.app/api/svg?text=PURPLE&dotOn=ff00ff&dotOff=330033&background=1a0a1a&dotSize=22&spacing=2 -->
+![Purple Theme](https://flipdots.vercel.app/api/svg?text=PURPLE&dotOn=ff00ff&dotOff=330033&background=1a0a1a&dotSize=22&spacing=2&v=1)
+```markdown
+https://flipdots.vercel.app/api/svg?text=PURPLE&dotOn=ff00ff&dotOff=330033&background=1a0a1a&dotSize=22&spacing=2
+```
 
 ## 🎬 애니메이션 예제
 
 ### Sequential Animation (순차 애니메이션)
 실제 flip-dot처럼 각 dot가 순차적으로 뒤집히는 애니메이션
 
-![Sequential Animation](https://flipdots.vercel.app/api/svg?text=SEQUENTIAL&animationMode=sequential&style=retro&dotSize=18&spacing=2)
-<!-- https://flipdots.vercel.app/api/svg?text=SEQUENTIAL&animationMode=sequential&style=retro&dotSize=18&spacing=2 -->
-
+![Sequential Animation](https://flipdots.vercel.app/api/svg?text=SEQUENTIAL&animationMode=sequential&style=retro&dotSize=18&spacing=2&v=1)
 ```markdown
-![Sequential Animation](https://flipdots.vercel.app/api/svg?text=SEQUENTIAL&animationMode=sequential&style=retro)
+https://flipdots.vercel.app/api/svg?text=SEQUENTIAL&animationMode=sequential&style=retro&dotSize=18&spacing=2
 ```
 
 ### Scroll Animation (스크롤 애니메이션)
 텍스트가 오른쪽에서 왼쪽으로 스크롤되는 애니메이션
 
-![Scroll Animation](https://flipdots.vercel.app/api/svg?text=HELLO_WORLD!&animationMode=scroll&style=modern&dotSize=16&spacing=1)
-<!-- https://flipdots.vercel.app/api/svg?text=HELLO_WORLD!&animationMode=scroll&style=modern&dotSize=16&spacing=1 -->
-
+![Scroll Animation](https://flipdots.vercel.app/api/svg?text=HELLO_WORLD!&animationMode=scroll&style=modern&dotSize=16&spacing=1&v=1)
 ```markdown
-![Scroll Animation](https://flipdots.vercel.app/api/svg?text=HELLO_WORLD!&animationMode=scroll&style=modern)
+https://flipdots.vercel.app/api/svg?text=HELLO_WORLD!&animationMode=scroll&style=modern&dotSize=16&spacing=1
 ```
 
 ## ✨ 특수 기능
@@ -129,19 +138,19 @@ GitHub README.md에 직접 임베드할 수 있는 flip dot 이미지를 생성�
 - **특수문자**: `! ? . , : ; - + = * / \ ( ) [ ] @ # $ % &` 지원
 - **URL 인코딩**: 특수문자가 URL에서 자동으로 인코딩되어도 정상 처리
 
-![Special Characters](https://flipdots.vercel.app/api/svg?text=HELLO_WORLD!&style=dark&dotSize=18&spacing=2)
-<!-- https://flipdots.vercel.app/api/svg?text=HELLO_WORLD!&style=dark&dotSize=18&spacing=2 -->
-
-![URL Example](https://flipdots.vercel.app/api/svg?text=GITHUB.COM/USER&style=modern&dotSize=16&spacing=2)
-<!-- https://flipdots.vercel.app/api/svg?text=GITHUB.COM/USER&style=modern&dotSize=16&spacing=2 -->
-
-![Score Example](https://flipdots.vercel.app/api/svg?text=SCORE:_100%25&style=retro&dotSize=18&spacing=2)
-<!-- https://flipdots.vercel.app/api/svg?text=SCORE:_100%25&style=retro&dotSize=18&spacing=2 -->
-
+![Special Characters](https://flipdots.vercel.app/api/svg?text=HELLO_WORLD!&style=dark&dotSize=18&spacing=2&v=1)
 ```markdown
-![Special Characters](https://flipdots.vercel.app/api/svg?text=HELLO_WORLD!&style=dark)
-![URL Example](https://flipdots.vercel.app/api/svg?text=GITHUB.COM/USER&style=modern)
-![Score Example](https://flipdots.vercel.app/api/svg?text=SCORE:_100%25&style=retro)
+https://flipdots.vercel.app/api/svg?text=HELLO_WORLD!&style=dark&dotSize=18&spacing=2
+```
+
+![URL Example](https://flipdots.vercel.app/api/svg?text=GITHUB.COM/USER&style=modern&dotSize=16&spacing=2&v=1)
+```markdown
+https://flipdots.vercel.app/api/svg?text=GITHUB.COM/USER&style=modern&dotSize=16&spacing=2
+```
+
+![Score Example](https://flipdots.vercel.app/api/svg?text=SCORE:_100%25&style=retro&dotSize=18&spacing=2&v=1)
+```markdown
+https://flipdots.vercel.app/api/svg?text=SCORE:_100%25&style=retro&dotSize=18&spacing=2
 ```
 
 *참고: URL에서 `%`는 `%25`로 인코딩됩니다.*
@@ -149,36 +158,39 @@ GitHub README.md에 직접 임베드할 수 있는 flip dot 이미지를 생성�
 ## 💡 사용 사례
 
 ### 프로필 헤더
+![Profile Header](https://flipdots.vercel.app/api/svg?text=WELCOME_TO_MY_PROFILE&animationMode=scroll&style=dark&dotSize=14&spacing=1&v=1)
 ```markdown
-![Profile Header](https://flipdots.vercel.app/api/svg?text=WELCOME_TO_MY_PROFILE&animationMode=scroll&style=dark&dotSize=14&spacing=1)
-<!-- https://flipdots.vercel.app/api/svg?text=WELCOME_TO_MY_PROFILE&animationMode=scroll&style=dark&dotSize=14&spacing=1 -->
+https://flipdots.vercel.app/api/svg?text=WELCOME_TO_MY_PROFILE&animationMode=scroll&style=dark&dotSize=14&spacing=1
 ```
 
 ### 프로젝트 제목
+![Project Title](https://flipdots.vercel.app/api/svg?text=MY_AWESOME_PROJECT&animationMode=sequential&style=retro&dotSize=18&spacing=2&v=1)
 ```markdown
-![Project Title](https://flipdots.vercel.app/api/svg?text=MY_AWESOME_PROJECT&animationMode=sequential&style=retro&dotSize=18&spacing=2)
-<!-- https://flipdots.vercel.app/api/svg?text=MY_AWESOME_PROJECT&animationMode=sequential&style=retro&dotSize=18&spacing=2 -->
+https://flipdots.vercel.app/api/svg?text=MY_AWESOME_PROJECT&animationMode=sequential&style=retro&dotSize=18&spacing=2
 ```
 
 ### 상태 표시
-```markdown
-![Build Status](https://flipdots.vercel.app/api/svg?text=BUILD_PASSING&dotOn=00ff00&background=000000&dotSize=16&spacing=2)
-<!-- https://flipdots.vercel.app/api/svg?text=BUILD_PASSING&dotOn=00ff00&background=000000&dotSize=16&spacing=2 -->
+![Build Status](https://flipdots.vercel.app/api/svg?text=BUILD_PASSING&dotOn=00ff00&background=000000&dotSize=16&spacing=2&v=1)
 
-![Version](https://flipdots.vercel.app/api/svg?text=V2.0.1&style=modern&dotSize=20&spacing=2)
-<!-- https://flipdots.vercel.app/api/svg?text=V2.0.1&style=modern&dotSize=20&spacing=2 -->
+![Version](https://flipdots.vercel.app/api/svg?text=V2%2E0%2E1&style=modern&dotSize=20&spacing=2&v=1)
+```markdown
+https://flipdots.vercel.app/api/svg?text=BUILD_PASSING&dotOn=00ff00&background=000000&dotSize=16&spacing=2&v=1
+
+https://flipdots.vercel.app/api/svg?text=V2.0.1&style=modern&dotSize=20&spacing=2&v=1
 ```
 
 ### 특수문자를 활용한 브랜딩
+![Personal Brand](https://flipdots.vercel.app/api/svg?text=@DEVELOPER&animationMode=scroll&dotOn=333333&background=FFFFFF&dotOff=EEEEEE&dotSize=22&spacing=3&v=1)
+
+![Contact Info](https://flipdots.vercel.app/api/svg?text=EMAIL@DOMAIN%2ECOM&style=modern&dotSize=16&spacing=2&v=1)
+
+![Achievement](https://flipdots.vercel.app/api/svg?text=100%25_COMPLETE!&style=retro&dotOn=00ff00&dotSize=18&spacing=2&v=1)
 ```markdown
-![Personal Brand](https://flipdots.vercel.app/api/svg?text=@DEVELOPER&animationMode=scroll&dotOn=ff6b35,f7931e,ffcc02&background=2c3e50&dotSize=22&spacing=3)
-<!-- https://flipdots.vercel.app/api/svg?text=@DEVELOPER&animationMode=scroll&dotOn=ff6b35,f7931e,ffcc02&background=2c3e50&dotSize=22&spacing=3 -->
+https://flipdots.vercel.app/api/svg?text=@DEVELOPER&animationMode=scroll&dotOn=ff6b35,f7931e,ffcc02&background=2c3e50&dotSize=22&spacing=3&v=1
 
-![Contact Info](https://flipdots.vercel.app/api/svg?text=EMAIL@DOMAIN.COM&style=modern&dotSize=16&spacing=2)
-<!-- https://flipdots.vercel.app/api/svg?text=EMAIL@DOMAIN.COM&style=modern&dotSize=16&spacing=2 -->
+https://flipdots.vercel.app/api/svg?text=EMAIL@DOMAIN.COM&style=modern&dotSize=16&spacing=2&v=1
 
-![Achievement](https://flipdots.vercel.app/api/svg?text=100%25_COMPLETE!&style=retro&dotOn=00ff00&dotSize=18&spacing=2)
-<!-- https://flipdots.vercel.app/api/svg?text=100%25_COMPLETE!&style=retro&dotOn=00ff00&dotSize=18&spacing=2 -->
+https://flipdots.vercel.app/api/svg?text=100%25_COMPLETE!&style=retro&dotOn=00ff00&dotSize=18&spacing=2&v=1
 ```
 
 ## 🛠️ 고급 사용법
@@ -186,43 +198,30 @@ GitHub README.md에 직접 임베드할 수 있는 flip dot 이미지를 생성�
 ### 그라디언트 효과
 여러 색상을 콤마로 구분하여 무지개 효과를 만들 수 있습니다:
 
-![Rainbow Effect](https://flipdots.vercel.app/api/svg?text=RAINBOW&dotOn=ff0000,ff8000,ffff00,00ff00,0080ff,0000ff,8000ff&background=000000&dotSize=20&spacing=2)
-<!-- https://flipdots.vercel.app/api/svg?text=RAINBOW&dotOn=ff0000,ff8000,ffff00,00ff00,0080ff,0000ff,8000ff&background=000000&dotSize=20&spacing=2 -->
+![Rainbow Effect](https://flipdots.vercel.app/api/svg?text=RAINBOW&dotOn=ff0000,ff8000,ffff00,00ff00,0080ff,0000ff,8000ff&background=000000&dotSize=20&spacing=2&v=1)
+
 
 ```markdown
-![Rainbow](https://flipdots.vercel.app/api/svg?text=RAINBOW&dotOn=ff0000,ff8000,ffff00,00ff00,0080ff,0000ff,8000ff&background=000000)
-```
-
-### 브랜드 색상 매칭
-```markdown
-<!-- GitHub 스타일 -->
-![GitHub](https://flipdots.vercel.app/api/svg?text=GITHUB&dotOn=ffffff&background=24292e&dotSize=18&spacing=2)
-<!-- https://flipdots.vercel.app/api/svg?text=GITHUB&dotOn=ffffff&background=24292e&dotSize=18&spacing=2 -->
-
-<!-- VS Code 스타일 -->
-![VS Code](https://flipdots.vercel.app/api/svg?text=VSCODE&dotOn=007acc&background=1e1e1e&dotSize=18&spacing=2)
-<!-- https://flipdots.vercel.app/api/svg?text=VSCODE&dotOn=007acc&background=1e1e1e&dotSize=18&spacing=2 -->
-
-<!-- React 스타일 -->
-![React](https://flipdots.vercel.app/api/svg?text=REACT&dotOn=61dafb&background=20232a&dotSize=18&spacing=2)
-<!-- https://flipdots.vercel.app/api/svg?text=REACT&dotOn=61dafb&background=20232a&dotSize=18&spacing=2 -->
+https://flipdots.vercel.app/api/svg?text=RAINBOW&dotOn=ff0000,ff8000,ffff00,00ff00,0080ff,0000ff,8000ff&background=000000
 ```
 
 ### 크기 조정
 다양한 용도에 맞는 크기 설정:
 
+![Small Badge](https://flipdots.vercel.app/api/svg?text=API&style=modern&dotSize=12&spacing=1&v=1)
+
+![Medium Title](https://flipdots.vercel.app/api/svg?text=MEDIUM&style=retro&dotSize=20&spacing=2&v=1)
+
+![Large Header](https://flipdots.vercel.app/api/svg?text=LARGE&style=dark&dotSize=30&spacing=3&v=1)
 ```markdown
 <!-- 작은 배지 스타일 -->
-![Small Badge](https://flipdots.vercel.app/api/svg?text=API&style=modern&dotSize=12&spacing=1)
-<!-- https://flipdots.vercel.app/api/svg?text=API&style=modern&dotSize=12&spacing=1 -->
+https://flipdots.vercel.app/api/svg?text=API&style=modern&dotSize=12&spacing=1
 
 <!-- 중간 제목 스타일 -->
-![Medium Title](https://flipdots.vercel.app/api/svg?text=MEDIUM&style=retro&dotSize=20&spacing=2)
-<!-- https://flipdots.vercel.app/api/svg?text=MEDIUM&style=retro&dotSize=20&spacing=2 -->
+https://flipdots.vercel.app/api/svg?text=MEDIUM&style=retro&dotSize=20&spacing=2
 
 <!-- 큰 헤더 스타일 -->
-![Large Header](https://flipdots.vercel.app/api/svg?text=LARGE&style=dark&dotSize=30&spacing=3)
-<!-- https://flipdots.vercel.app/api/svg?text=LARGE&style=dark&dotSize=30&spacing=3 -->
+https://flipdots.vercel.app/api/svg?text=LARGE&style=dark&dotSize=30&spacing=3
 ```
 
 ## 📖 애니메이션 특징
@@ -255,12 +254,6 @@ GitHub README.md에 직접 임베드할 수 있는 flip dot 이미지를 생성�
 - **숫자**: 0-9  
 - **공백**: 단어 구분용
 - **특수 문자**: 제한적 지원
-
-## 🚀 성능 최적화
-
-- **캐싱**: `Cache-Control: public, max-age=31536000, immutable`
-- **경량화**: 최적화된 SVG 생성
-- **응답성**: 빠른 이미지 생성과 전송
 
 ## 📝 라이센스
 


### PR DESCRIPTION
This pull request updates the `README.md` to improve the documentation and usage examples for embedding flip dot images in GitHub READMEs. The changes focus on making the instructions clearer, standardizing example formats, and updating image URLs to include a cache-busting parameter.

**Documentation and Example Improvements:**

* Updated all example image URLs to include a `&v=1` query parameter for cache busting, ensuring users always see the latest version of generated images. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L22-R22) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L81-R131) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L132-R224)
* Replaced previous markdown image embedding examples with direct image URLs and added corresponding markdown code blocks for easier copy-paste and clarity. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L43-R51) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L81-R131) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L132-R224)
* Added new visual examples for various use cases (profile header, project title, build status, branding, etc.), including different styles, custom colors, gradients, and size adjustments.
* Improved organization and readability by grouping related examples and removing redundant or commented-out code. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L81-R131) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L132-R224)
* Removed the "성능 최적화" (Performance Optimization) section, streamlining the documentation.