### PR TITLE
Github redirect link added

### DIFF
--- a/components/layout/footer.js
+++ b/components/layout/footer.js
@@ -1,5 +1,6 @@
 "use client";
 import styled from 'styled-components'
+import { FaGithub } from 'react-icons/fa'
 
 const StyledFooter = styled.div`
     background : black;
@@ -19,8 +20,27 @@ export default function Footer() {
             <div>
                 @Hangeol-Chang All rights reserved
             </div>
-            <div>
-                connect Info
+            <div style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: '8px'
+            }}>
+                <span>GitHub:</span>
+                <a 
+                    href="https://github.com/Hangeol-Chang" 
+                    target="_blank" 
+                    rel="noopener noreferrer"
+                    style={{
+                        color: 'white',
+                        textDecoration: 'none',
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: '4px'
+                    }}
+                >
+                    <FaGithub size={20} />
+                    Hangeol-Chang
+                </a>
             </div>
         </StyledFooter>
     )

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "next": "14.2.5",
         "react": "18.3.1",
         "react-dom": "18.3.1",
+        "react-icons": "^5.5.0",
         "recoil": "^0.7.7",
         "styled-components": "^6.1.11"
       },
@@ -3523,6 +3524,15 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "next": "14.2.5",
     "react": "18.3.1",
     "react-dom": "18.3.1",
+    "react-icons": "^5.5.0",
     "recoil": "^0.7.7",
     "styled-components": "^6.1.11"
   },

--- a/src/app/example/page.js
+++ b/src/app/example/page.js
@@ -1,5 +1,6 @@
 'use client';
 import { useState, useEffect } from 'react';
+import { FaGithub } from 'react-icons/fa';
 
 export default function ExamplePage() {
     const [mode, setMode] = useState('text'); // 'text' 또는 'custom'
@@ -70,7 +71,30 @@ export default function ExamplePage() {
             margin: '0 auto',
             color: 'white'
         }}>
-            <h1>Flip Dot API Example</h1>
+            <div style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: '15px',
+                marginBottom: '10px'
+            }}>
+                <h1 style={{ margin: 0 }}>Flip Dot API Example</h1>
+                <a 
+                    href="https://github.com/Hangeol-Chang/flipdot" 
+                    target="_blank" 
+                    rel="noopener noreferrer"
+                    style={{
+                        color: 'white',
+                        display: 'flex',
+                        alignItems: 'center',
+                        textDecoration: 'none',
+                        transition: 'opacity 0.2s'
+                    }}
+                    onMouseOver={(e) => e.currentTarget.style.opacity = '0.7'}
+                    onMouseOut={(e) => e.currentTarget.style.opacity = '1'}
+                >
+                    <FaGithub size={32} />
+                </a>
+            </div>
             <p>GitHub README.md에서 사용할 수 있는 flip dot 이미지를 생성하는 API입니다.</p>
             
             {/* 예제 텍스트 - 태그 스타일 */}


### PR DESCRIPTION
This pull request introduces improvements to the user interface by adding GitHub profile and repository links with icons in both the footer and the example page. Additionally, it adds the `react-icons` library as a new dependency to support these icons.

**UI Enhancements:**

* Added a GitHub icon and profile link (`Hangeol-Chang`) to the footer for easier access to the author's GitHub page. (`components/layout/footer.js`) [[1]](diffhunk://#diff-30a1e5fece559984df2ee7174310c3256c7f9ad35e9bec23fa4a71bbd6eef762R3) [[2]](diffhunk://#diff-30a1e5fece559984df2ee7174310c3256c7f9ad35e9bec23fa4a71bbd6eef762L22-R43)
* Updated the example page header to include a GitHub icon linking to the `flipdot` repository, improving visibility and navigation. (`src/app/example/page.js`) [[1]](diffhunk://#diff-a47b61305b84a3d414a41fcf6eefda3a8c90b30505bd33277701df7a0f800051R3) [[2]](diffhunk://#diff-a47b61305b84a3d414a41fcf6eefda3a8c90b30505bd33277701df7a0f800051L73-R97)

**Dependency Updates:**

* Added the `react-icons` package to `package.json` to enable usage of icon components throughout the project. (`package.json`)